### PR TITLE
Fix compiler errors for avr-gcc

### DIFF
--- a/examples/select/select.ino
+++ b/examples/select/select.ino
@@ -34,7 +34,7 @@ PubSubClient mqtt_client(wifi_client);
 #define HA_DEVICE_FRIENDLY_NAME "Example Select HA-MQTT"
 
 #define OPTIONS_COUNT 3
-const char *select_options[OPTIONS_COUNT] PROGMEM = {
+const char *const select_options[OPTIONS_COUNT] PROGMEM = {
      "Option 1",
      "Option 2",
      "Option 3"

--- a/src/habutton.cpp
+++ b/src/habutton.cpp
@@ -3,7 +3,7 @@
 
 #include<habutton.h>
 
-const char *HAButton::component PROGMEM  = "button";
+const char *const HAButton::component PROGMEM = "button";
 
 HAButton::HAButton(const char *unique_id, const char *name, HADevice& device):
     HAEntity(unique_id,name,component,&device) {

--- a/src/habutton.h
+++ b/src/habutton.h
@@ -18,7 +18,7 @@ class HADevice;
 
 class HAButton : public HAEntity {
     protected:
-        static const char *component;        
+        static const char *const component;
 
     public:
         HAButton(const char *unique_id,const char *name,HADevice& device);

--- a/src/hadevice.cpp
+++ b/src/hadevice.cpp
@@ -6,8 +6,7 @@
 #include <stdio.h>
 #include <Arduino.h>
 
-
-const char *HADevice::configDeviceTemplate PROGMEM = "\
+const char *const HADevice::configDeviceTemplate PROGMEM = "\
 \"dev\":{\
 \"ids\":\"%s\",\
 \"name\":\"%s\",\
@@ -15,7 +14,7 @@ const char *HADevice::configDeviceTemplate PROGMEM = "\
 
 
 // Available topic shared by all entities
-const char *HADevice::availabilityTopicTemplate PROGMEM = \
+const char *const HADevice::availabilityTopicTemplate PROGMEM = \
     HA_TOPIC_HEAD"/%s/available";
 
 

--- a/src/hadevice.h
+++ b/src/hadevice.h
@@ -1,8 +1,8 @@
 #ifndef __HA_DEVICE_H__
 #define __HA_DEVICE_H__
 
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "haconsts.h"
 
@@ -10,8 +10,8 @@ class PubSubClient;
 
 class HADevice {
     protected:
-        static const char *configDeviceTemplate;
-        static const char *availabilityTopicTemplate;
+        static const char *const configDeviceTemplate;
+        static const char *const availabilityTopicTemplate;
 
         char *identifier;
         char *name;

--- a/src/haentity.cpp
+++ b/src/haentity.cpp
@@ -11,26 +11,29 @@
 */
 
 // Configuration topic
-const char *HAEntity::configTopicTemplate PROGMEM = "homeassistant/%s/%s/config";
+const char *const HAEntity::configTopicTemplate PROGMEM =
+    "homeassistant/%s/%s/config";
 
 // Configuration payload parts
-const char *HAEntity::configPayloadTemplate PROGMEM = "{\
+const char *const HAEntity::configPayloadTemplate PROGMEM = "{\
 \"~\":\"homeassistant/%s/%s\",\
 \"name\":\"%s\",\
 \"uniq_id\":\"%s\"";
 
-const char *HAEntity::commandTopicTemplate PROGMEM = "homeassistant/%s/%s/set";
-const char *HAEntity::stateTopicTemplate PROGMEM = "homeassistant/%s/%s/state";
-const char *HAEntity::availabilityTopicTemplate PROGMEM =
+const char *const HAEntity::commandTopicTemplate PROGMEM =
+    "homeassistant/%s/%s/set";
+const char *const HAEntity::stateTopicTemplate PROGMEM =
+    "homeassistant/%s/%s/state";
+const char *const HAEntity::availabilityTopicTemplate PROGMEM =
     "homeassistant/%s/%s/available";
 
 
-const char *HAEntity::featureKeys[] PROGMEM = {
+const char *const HAEntity::featureKeys[] PROGMEM = {
     "dev_cla",
     "ic",
     "ent_cat",
     "mode"
-    };
+};
 
 
 HAEntity::HAEntity(const char *id,const char *name,const char *component,

--- a/src/haentity.h
+++ b/src/haentity.h
@@ -24,13 +24,13 @@ class HAEntity
  {
     protected:
 
-        static const char *configTopicTemplate;
-        static const char *configPayloadTemplate;
-        static const char *availabilityTopicTemplate;
-        static const char *featureKeys[];
+        static const char *const configTopicTemplate;
+        static const char *const configPayloadTemplate;
+        static const char *const availabilityTopicTemplate;
+        static const char *const featureKeys[];
 
-        static const char *commandTopicTemplate;
-        static const char *stateTopicTemplate;
+        static const char *const commandTopicTemplate;
+        static const char *const stateTopicTemplate;
 
         HADevice *device;
         const char *id;

--- a/src/hakvpairlist.h
+++ b/src/hakvpairlist.h
@@ -1,7 +1,7 @@
 #ifndef __HAKVPAIRLIST_H__
 #define __HAKVPAIRLIST_H__
 
-#include <cstddef>
+#include <stddef.h>
 
 class HAKVPairList {
     protected:

--- a/src/hamqttcontroller.cpp
+++ b/src/hamqttcontroller.cpp
@@ -1,5 +1,5 @@
-#include"hamqttcontroller.h"
-#include"hadevice.h"
+#include "hamqttcontroller.h"
+#include "hadevice.h"
 
 // When the broker is restarted, the data sent will be lost if HA is not
 // connected first. This is the time to wait for HA to connect.
@@ -9,7 +9,7 @@
 // enable the entities before sending states
 #define HA_DELAY_SEND_STATES 3000
 
-const char *HAMQTTController::topicHass PROGMEM = "homeassistant/status";
+const char *const HAMQTTController::topicHass PROGMEM = "homeassistant/status";
 
 HAMQTTController *HAMQTTController::instance = new HAMQTTController();
 

--- a/src/hamqttcontroller.h
+++ b/src/hamqttcontroller.h
@@ -24,7 +24,7 @@ class HAMQTTController {
 
     private:
         static HAMQTTController *instance;
-        static const char *topicHass;
+        static const char *const topicHass;
         HAMQTT_CALLBACK_SIGNATURE(callback);
         HAMQTTController();
 

--- a/src/hanumber.cpp
+++ b/src/hanumber.cpp
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 #include <PubSubClient.h>
 
-const char *HANumber::component PROGMEM  = "number";
+const char *const HANumber::component PROGMEM = "number";
 
 HANumber::HANumber(const char *unique_id, const char *name,
     HADevice& device,int min,int max,const int step):

--- a/src/hanumber.h
+++ b/src/hanumber.h
@@ -8,7 +8,7 @@ class HADevice;
 
 class HANumber : public HAEntity {
     protected:
-        static const char *component;
+        static const char *const component;
 
         bool dirty;
         int state;

--- a/src/haselect.cpp
+++ b/src/haselect.cpp
@@ -2,9 +2,9 @@
 #include <PubSubClient.h>
 #include <haselect.h>
 
-const char *HASelect::component PROGMEM  = "select";
+const char *const HASelect::component PROGMEM = "select";
 
-HASelect::HASelect(const char *unique_id, const char *name, u_int8_t max_options):
+HASelect::HASelect(const char *unique_id, const char *name, uint8_t max_options):
     HAEntity(unique_id,name,component)
 {
     this->maxOptions = max_options;
@@ -13,7 +13,7 @@ HASelect::HASelect(const char *unique_id, const char *name, u_int8_t max_options
     this->options = new char*[max_options];
 }
 
-HASelect::HASelect(const char *unique_id,const char *name, u_int8_t max_options,
+HASelect::HASelect(const char *unique_id, const char *name, uint8_t max_options,
     const char *options[]) : HAEntity(unique_id,name,component) {
     this->maxOptions = max_options;
     this->state = NULL;
@@ -22,12 +22,12 @@ HASelect::HASelect(const char *unique_id,const char *name, u_int8_t max_options,
 }
 
 HASelect::HASelect(const char *unique_id, const char *name, HADevice& device,
-    u_int8_t max_options):HASelect(unique_id,name,max_options) {
+    uint8_t max_options):HASelect(unique_id,name,max_options) {
         this->device = &device;
 }
 
 HASelect::HASelect(const char *unique_id, const char *name,
-    HADevice& device, u_int8_t max_options, const char* options[]):
+    HADevice& device, uint8_t max_options, const char* options[]):
     HASelect(unique_id,name,max_options,options) {
         this->device = &device;
 }

--- a/src/haselect.h
+++ b/src/haselect.h
@@ -9,26 +9,26 @@ class HADevice;
 class HASelect : public HAEntity {
     protected:
 
-        static const char *component;
+        static const char *const component;
 
         bool dirty;
         char *state; // The selected option
-        u_int8_t maxOptions;
-        u_int8_t optionsAdded;
+        uint8_t maxOptions;
+        uint8_t optionsAdded;
         char **options;
 
     public:
 
         /// Constructor without device
-        HASelect(const char *unique_id,const char *name,u_int8_t max_options);
-        HASelect(const char *unique_id,const char *name, u_int8_t max_options,
+        HASelect(const char *unique_id, const char *name, uint8_t max_options);
+        HASelect(const char *unique_id, const char *name, uint8_t max_options,
             const char *options[]);
 
         /// Constructor with device
-        HASelect(const char *unique_id,const char *name,HADevice& device,
-            u_int8_t max_options);
-        HASelect(const char *unique_id,const char *name, HADevice& device,
-            u_int8_t max_options, const char *options[]);
+        HASelect(const char *unique_id, const char *name, HADevice& device,
+            uint8_t max_options);
+        HASelect(const char *unique_id, const char *name, HADevice& device,
+            uint8_t max_options, const char *options[]);
 
 
         void addOption(const char *option);

--- a/src/hasensor.cpp
+++ b/src/hasensor.cpp
@@ -2,11 +2,11 @@
 #include <PubSubClient.h>
 #include <hasensor.h>
 
-const char *HASensor::component PROGMEM  = "sensor";
+const char *const HASensor::component PROGMEM = "sensor";
 
-HASensor::HASensor(const char *unique_id, const char *name, 
+HASensor::HASensor(const char *unique_id, const char *name,
     const char * component) :  HAEntity(unique_id,name,component) {
-    
+
 }
 
 void HASensor::onConnect(PubSubClient * client){

--- a/src/hasensor.h
+++ b/src/hasensor.h
@@ -9,11 +9,11 @@ class HADevice;
 class HASensor : public HAEntity {
     protected:
 
-        static const char *component;
+        static const char *const component;
         bool dirty;
 
     public:
-        HASensor(const char *unique_id, const char *name, 
+        HASensor(const char *unique_id, const char *name,
             const char * component = HASensor::component);
         inline bool isDirty() {return this->dirty;};
         virtual void onConnect(PubSubClient * client);

--- a/src/hasensorbinary.cpp
+++ b/src/hasensorbinary.cpp
@@ -3,7 +3,7 @@
 
 #include <hasensorbinary.h>
 
-const char *HASensorBinary::component PROGMEM  = "binary_sensor";
+const char *const HASensorBinary::component PROGMEM = "binary_sensor";
 
 HASensorBinary::HASensorBinary(const char *unique_id, const char *name,
     HADevice& device) : HASensor(unique_id,name,component)

--- a/src/hasensorbinary.h
+++ b/src/hasensorbinary.h
@@ -8,7 +8,7 @@ class HADevice;
 
 class HASensorBinary : public HASensor {
     protected:
-        static const char *component;
+        static const char *const component;
         bool state;
 
     public:

--- a/src/haswitch.cpp
+++ b/src/haswitch.cpp
@@ -6,7 +6,7 @@
 
 #include "hadevice.h"
 
-const char *HASwitch::component PROGMEM  = "switch";
+const char *const HASwitch::component PROGMEM = "switch";
 
 HASwitch::HASwitch(const char *unique_id, const char *name, HADevice& device):
     HASwitch(unique_id,name) {

--- a/src/haswitch.h
+++ b/src/haswitch.h
@@ -8,7 +8,7 @@ class HADevice;
 
 class HASwitch : public HAEntity {
     protected:
-        static const char *component;
+        static const char *const component;
 
         bool dirty;
         bool state;

--- a/src/hatext.cpp
+++ b/src/hatext.cpp
@@ -6,7 +6,7 @@
 
 #include <hatext.h>
 
-const char *HAText::component PROGMEM  = "text";
+const char *const HAText::component PROGMEM = "text";
 
 HAText::HAText(const char *unique_id, const char *name, HADevice& device,
     unsigned int max_size):HAText(unique_id,name,max_size) {

--- a/src/hatext.h
+++ b/src/hatext.h
@@ -9,7 +9,7 @@ class HADevice;
 class HAText : public HAEntity {
     protected:
 
-        static const char *component;
+        static const char *const component;
 
         bool dirty;
         char *state;


### PR DESCRIPTION
This patch fixes compiler errors for the Atmel AVR target:
```
$ pio run

Processing uno (platform: atmelavr; framework: arduino; board: uno)                                                                                       
--------------------------------------------------------------------------------                                                                          
Verbose mode can be enabled via `-v, --verbose` option                                                                                                    
CONFIGURATION: https://docs.platformio.org/page/boards/atmelavr/uno.html                                                                                  
PLATFORM: Atmel AVR (5.1.0) > Arduino Uno                                                                                                                 
HARDWARE: ATMEGA328P 16MHz, 2KB RAM, 31.50KB Flash                                                                                                        
DEBUG: Current (avr-stub) External (avr-stub, simavr)                                                                                                     
PACKAGES:                                                                                                                                                 
 - framework-arduino-avr @ 5.2.0                                                                                                                          
 - tool-avrdude @ 1.60300.200527 (6.3.0)                                                                                                                  
 - toolchain-atmelavr @ 1.70300.191015 (7.3.0)                                                                                                            
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf                                                                                        
LDF Modes: Finder ~ chain, Compatibility ~ soft                                                                                                           
Found 10 compatible libraries                                                                                                                             
Scanning dependencies...                                                                                                                                  
Dependency Graph                                                                                                                                          
|-- HaMqttEntities @ 1.0.10                                                                                                                               
|-- ArduinoJson @ 7.4.2                                                                                                                                   
Building in release mode                                                                                                                                  
Archiving .pio/build/uno/libb27/libPubSubClient.a                                                                                                         
Indexing .pio/build/uno/libb27/libPubSubClient.a                                                                                                          
Compiling .pio/build/uno/lib1aa/HaMqttEntities/habutton.cpp.o                                                                                             
Compiling .pio/build/uno/lib1aa/HaMqttEntities/hadevice.cpp.o                                                                                             
Compiling .pio/build/uno/lib1aa/HaMqttEntities/habutton.cpp.o
Compiling .pio/build/uno/lib1aa/HaMqttEntities/hadevice.cpp.o
In file included from .pio/libdeps/uno/HaMqttEntities/src/hadevice.cpp:1:0:
.pio/libdeps/uno/HaMqttEntities/src/hadevice.h:4:10: fatal error: cstddef: No such file or directory
 #include <cstddef>
          ^~~~~~~~~
compilation terminated.
*** [.pio/build/uno/lib1aa/HaMqttEntities/hadevice.cpp.o] Error 1
In file included from /home/arnie97/.platformio/packages/framework-arduino-avr/cores/arduino/Arduino.h:28:0,
                 from .pio/libdeps/uno/HaMqttEntities/src/habutton.cpp:1:
.pio/libdeps/uno/HaMqttEntities/src/habutton.cpp:6:33: error: variable 'HAButton::component' must be const in order to be put into read-only section by means of '__attribute__((progmem))'
 const char *HAButton::component PROGMEM  = "button";
                                 ^
*** [.pio/build/uno/lib1aa/HaMqttEntities/habutton.cpp.o] Error 1
```